### PR TITLE
Changed JS position requested to be in the onDocumentReady() function

### DIFF
--- a/widgets/select2/WhSelect2.php
+++ b/widgets/select2/WhSelect2.php
@@ -108,7 +108,7 @@ class WhSelect2 extends CInputWidget
         /* initialize plugin */
         $selector = '#' . TbArray::getValue('id', $this->htmlOptions, $this->getId());
 
-        $this->getApi()->registerPlugin('select2', $selector, $this->pluginOptions);
-        $this->getApi()->registerEvents($selector, $this->events);
+        $this->getApi()->registerPlugin('select2', $selector, $this->pluginOptions, CClientScript::POS_READY);
+        $this->getApi()->registerEvents($selector, $this->events, CClientScript::POS_READY);
     }
 }


### PR DESCRIPTION
Select2 options don't take affect unless we're in the onReady() method.

@tonydspaniard I'm using a version I've hacked on a bit which is where I found the problem.  We haven't yet upgraded to Yiistrap / YiiWheels, but I'm pretty sure this is a bug in the native version as well.

Yiistrap's Bootstrap (`TbApi`) component's default `$position` for is `CClientScript::POS_END`, not `CClientScript::POS_READY`.

https://github.com/Crisu83/yiistrap/blob/master/components/TbApi.php#L176
https://github.com/Crisu83/yiistrap/blob/master/components/TbApi.php#L190
