### PR TITLE
Update WhHtml5Editor.php

### DIFF
--- a/widgets/html5editor/WhHtml5Editor.php
+++ b/widgets/html5editor/WhHtml5Editor.php
@@ -42,6 +42,20 @@ class WhHtml5Editor extends CInputWidget
      */
     public $height = '400px';
 
+    public function init()
+    {
+    
+    	$this->attachBehavior('ywplugin', array('class' => 'yiiwheels.behaviors.WhPlugin'));
+    
+    	if (!$style = TbArray::popValue('style', $this->htmlOptions, '')) {
+    		$this->htmlOptions['style'] = $style;
+    	}
+    
+    	$width                      = TbArray::getValue('width', $this->htmlOptions, '100%');
+    	$height                     = TbArray::popValue('height', $this->htmlOptions, '450px');
+    	$this->htmlOptions['style'] = "width:{$width};height:{$height};" . $this->htmlOptions['style'];
+    }
+
     /**
      * Display editor
      */


### PR DESCRIPTION
Get following CException when using html5editor. 
WhHtml5Editor and its behaviors do not have a method or closure named "getAssetsUrl".

WhHtml5Editor.php missing init() method. Adding init() method resolve exception.
