### PR TITLE
fix missing EditableField class

### DIFF
--- a/widgets/editable/WhEditable.php
+++ b/widgets/editable/WhEditable.php
@@ -468,7 +468,7 @@ class WhEditable extends CWidget
         //i18n for `clear` in date and datetime
         if ($this->type == 'date' || $this->type == 'datetime') {
             if (!isset($this->options['clear'])) {
-                $this->options['clear'] = Yii::t('EditableField.editable', 'x clear');
+                $this->options['clear'] = Yii::t('WhEditableField.editable', 'x clear');
             }
         }
     }


### PR DESCRIPTION
missing EditableField class when using `date` or `datetime` type editable widgets